### PR TITLE
Bugfixes and removal of support for `OSTYPE=msys`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,19 +36,21 @@ jobs:
           lfc --version
           lfd --version
           lff --version
-        #   which epoch
+          which epoch
         shell: bash
       - name: Install stable all
         run: |
           bash install.sh stable all
-        # FIXME currently not working. Uncomment after releasing v0.5.0
-        #   lfc --version
-        #   lff --version
+          lfc --version
+          lfd --version
+          lff --version
+          which epoch
         shell: bash
       - name: Install epoch cli
         run: |
           bash install.sh epoch cli
-        # FIXME currently not working. Uncomment after releasing v0.5.0
-        #  lfc --version
-        #  lff --version
+          lfc --version
+          lfd --version
+          lff --version
+          which epoch
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   install:
     strategy:
         matrix:
-          platform: ["ubuntu-latest", "macos-latest", "windows-latest"]
+          platform: ["ubuntu-latest", "macos-latest"]
     runs-on: ${{ matrix.platform }}  
     steps:
       - name: Setup Java JDK
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install nightly all
         run: |
-          bash install.sh nightly all
+          bash install.sh nightly all --prefix=~/.local
           lfc --version
           lfd --version
           lff --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install nightly all
         run: |
-          bash install.sh nightly all --prefix=~/.local
+          bash install.sh nightly all
           lfc --version
           lfd --version
           lff --version

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ else
   arch='x86_64'
 fi
 
-if [[ "$OSTYPE" == "linux"* || "$OSTYPE" == "msys" ]]; then
+if [[ "$OSTYPE" == "linux"* ]]; then
   os="Linux"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   os="MacOS"
@@ -25,30 +25,15 @@ else
   exit 1
 fi
 
-fwd() (
-  cat >$1 <<EOL
-#!/bin/sh
-$($2 $@)
-
-EOL
- chmod +x $1  
-)
-
 install() (
   case $1 in
     cli)
       mkdir -p $share/cli
       cp -rf $dir/* $share/cli
-      if [[ "$OSTYPE" == "msys" ]]; then
-        fwd $bin/lfc $share/cli/bin/lfc
-        fwd $bin/lfd $share/cli/bin/lfd
-        fwd $bin/lff $share/cli/bin/lff
-      else
-        ln -sf  $share/cli/bin/lfc $bin/lfc
-        ln -sf  $share/cli/bin/lfd $bin/lfd
-        ln -sf  $share/cli/bin/lff $bin/lff
-      fi
-    echo "    - Installed: $(ls -m $dir/bin/)"
+      ln -sf  $share/cli/bin/lfc $bin/lfc
+      ln -sf  $share/cli/bin/lfd $bin/lfd
+      ln -sf  $share/cli/bin/lff $bin/lff
+      echo "    - Installed: $(ls -m $dir/bin/)"
     ;;
     epoch)
       if [[ "$os" == "MacOS" ]]; then
@@ -63,7 +48,7 @@ install() (
         cp -rf $dir $share/
         ln -sf $share/epoch/epoch $bin/epoch
       fi
-    echo "    - Installed: epoch"
+      echo "    - Installed: epoch"
     ;;
   esac
   

--- a/install.sh
+++ b/install.sh
@@ -16,12 +16,10 @@ else
   arch='x86_64'
 fi
 
-os="Linux"
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ "$OSTYPE" == "linux"* || "$OSTYPE" == "msys" ]]; then
+  os="Linux"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
   os="MacOS"
-elif [[ "$OSTYPE" == "msys" ]]; then
-  echo "Git bash?"
-  exit 1
 else
   echo "Unsupported operating system: $OSTYPE"
   exit 1
@@ -145,6 +143,12 @@ if [[ -z $kind ]]; then
   kind="stable"
 fi
 
+if [[ "$kind" == "nightly" ]]; then
+  suffix="tags/nightly"
+else
+  suffix="latest"
+fi
+
 # Use ~/.local default prefix
 if [[ -z $prefix ]]; then
  if [[ "$os" == "MacOS" ]]; then
@@ -186,13 +190,8 @@ for tool in "${selected[@]}"; do
   case $tool in
     cli)
       description="CLI tools"
-      if [[ "$kind" = "nightly" ]]; then
-        rel="https://api.github.com/repos/lf-lang/lingua-franca/releases/tags/nightly"
-        kvp=$(curl -L -H "Accept: application/vnd.github+json" $rel 2>&1 | grep download_url | grep $os-$arch.tar.gz)
-      else
-        rel="https://api.github.com/repos/lf-lang/lingua-franca/releases/latest"
-        kvp=$(curl -L -H "Accept: application/vnd.github+json" $rel 2>&1 | grep download_url | grep lf-cli | grep tar.gz)
-      fi
+      rel="https://api.github.com/repos/lf-lang/lingua-franca/releases/$suffix"
+      kvp=$(curl -L -H "Accept: application/vnd.github+json" $rel 2>&1 | grep download_url | grep $os-$arch.tar.gz)
       arr=($kvp)
       url="${arr[1]//\"/}"
       file=$(echo $url | grep -o '[^/]*\.tar.gz')

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # Author: marten@berkeley.edu
 # License: BSD-2
 
-version="0.1.0-beta"
+version="0.1.0-beta-1"
 tools=("cli" "epoch")
 selected=()
 timestamp=$(date '+%Y%m%d%H%M%S')

--- a/install.sh
+++ b/install.sh
@@ -204,13 +204,8 @@ for tool in "${selected[@]}"; do
       elif [[ "$os" == "MacOS" ]]; then
         os_abbr="mac"
       fi
-      if [[ "$kind" == "nightly" ]]; then
-        rel="https://api.github.com/repos/lf-lang/epoch/releases/tags/nightly"
-        kvp=$(curl -L -H "Accept: application/vnd.github+json" $rel 2>&1 | grep "download_url" | grep "$arch" | grep "$os_abbr")
-      else
-        rel="https://api.github.com/repos/lf-lang/lingua-franca/releases/latest"
-        kvp=$(curl -L -H "Accept: application/vnd.github+json" $rel 2>&1 | grep "download_url" | grep "epoch" | grep "$arch" | grep "$os_abbr")
-      fi
+      rel="https://api.github.com/repos/lf-lang/epoch/releases/$suffix"
+      kvp=$(curl -L -H "Accept: application/vnd.github+json" $rel 2>&1 | grep "download_url" | grep "$arch" | grep "$os_abbr")
       arr=($kvp)
       url="${arr[1]//\"/}"
       if [[ "$os" == "MacOS" ]]; then


### PR DESCRIPTION
This PR fixes #20 and removes Windows support entirely because it wasn't working correctly in the first place. Addresses #19. We might want to furnish support for `OSTYPE` `msys` and `cygwin`, but we can do that at a later time. If we want to provide a script for installation on Windows, that will have to be a separate (PowerShell) script. Also see #22,  #23, and #24. 