### PR TITLE
Change default temporary storage location to $HOME/.tmp

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -150,9 +150,9 @@ if [[ -z $prefix ]]; then
   prefix=~/.local
 fi
 
-# Use /tmp as the default temporary storage
+# Use $HOME/.tmp as the default temporary storage
 if [[ -z $tmp ]]; then
-  tmp="/tmp/lingua-franca"
+  tmp="$HOME/.tmp/lingua-franca"
 else
   tmp="${tmp%/}/lingua-franca"
 fi


### PR DESCRIPTION
The script installs the temporary file inside `/tmp`, which is not accessible for users in multi-user servers without sudo.

I updated it to create the `.tmp` folder in their own `$HOME`.

This does not fix the default installation location, which is `~/.local/bin`